### PR TITLE
Fix display of logo on team page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
   		<span class="icon-bar"></span>
   	  </button>
 
-      <a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/"><img src="assets/dandi_logo.svg" alt="DANDI" /></a>
+      <a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/"><img src="{{ site.url }}{{ site.baseurl }}/assets/dandi_logo.svg" alt="DANDI" /></a>
   	</div>
   	<div class="collapse navbar-collapse" id="navbar-collapse-1">
   	  <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
When on the `team` page, the path to the logo becomes `https://dandiarchive.org/team/assets/dandi_logo.svg` and breaks the logo image display.

