### PR TITLE
Update team page to fix logo display

### DIFF
--- a/_pages/team.md
+++ b/_pages/team.md
@@ -3,7 +3,7 @@ title: "DANDI Team"
 layout: gridlay
 excerpt: "Members"
 sitemap: false
-permalink: /team/
+permalink: /team
 ---
 
 # Members


### PR DESCRIPTION
By removing the trailing slash on the team page, the relative path to the logo asset should resolve.