### PR TITLE
Add maintenance notice for migration

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,7 +29,9 @@
   </div>
 </div>
 {% if page.title == "DANDI Home" %}
-   <div class="alert top-alert" role="alert">
-    Help us help you! Please take our <strong><a href="https://docs.google.com/forms/d/e/1FAIpQLScT0KLxT8pgQ4y6_Wqa_1IPHKJOrxGJ6nPMwxh1QS3od3P1lw/viewform" class="alert-link">survey</a></strong> so we can learn about your data needs.
+   <div class="alert top-alert alert-warning" role="alert">
+     <h4 class="alert-heading">
+    DANDI is undergoing maintenance and is currently offline. We expect it to be back online by April 22nd, Noon Eastern Time.
+     </h4>
    </div>
 {% endif %}

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -8,3 +8,4 @@ permalink: /404.html
 
 Sorry, but the page you were trying to view does not exist.
 
+This may be because DANDI is undergoing maintenance and is currently offline. We expect it to be back online by April 22nd, noon Eastern Time.


### PR DESCRIPTION
We believe this is necessary for the migration, to have a maintenance notice on the root page, because DNS records that we repoint to the github.io page from e.g. girder.dandiarchive.org will not get redirected to the /maintenance.html page but to the root page.