### PR TITLE
Fix `Open Neurodata Showcase` link

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -21,7 +21,7 @@
 - date: 2023 08 28
   headline: >-
     Scientists who have publicly shared neurophysiology data on DANDI present their data at
-    <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK16_2023_OpenNeuroDataShowcase/">Open Neurodata Showcase 2023</a>
+    <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK17_2023_OpenNeuroDataShowcase/">Open Neurodata Showcase 2023</a>
 
 - date: 2022 10 04
   headline: > 


### PR DESCRIPTION
In the [News page](https://www.dandiarchive.org/allnews.html), the link to [Open Neurodata Showcase 2023](https://neurodatawithoutborders.github.io/nwb_hackathons/HCK16_2023_OpenNeuroDataShowcase/) goes to 404, since the page was renamed [here](https://github.com/NeurodataWithoutBorders/nwb_hackathons/pull/252).