### PR TITLE
Move `Home` button to the left of the top navigation bar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,9 @@
   	</div>
   	<div class="collapse navbar-collapse" id="navbar-collapse-1">
   	  <ul class="nav navbar-nav navbar-right">
-  		<li><a href="https://dandiarchive.org">Data Portal</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
+		<li><a href="https://dandiarchive.org">Data Portal</a></li>
   		<li><a href="https://www.dandiarchive.org/handbook/">Documentation</a></li>
-  		<li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
   		<li><a href="http://hub.dandiarchive.org">DandiHub</a></li>
   		  <!--
   		<li><a href="{{ site.url }}{{ site.baseurl }}/research">Research</a></li>


### PR DESCRIPTION
Currently, the `Home` button is in the middle of the top navigation bar.
![image](https://github.com/dandi/dandi.github.io/assets/871137/8ec0e286-31fe-43d9-b7d6-9117207e4768)

I propose moving the `Home` button to the left of the top navigation bar, so that it is more intuitive.
![image](https://github.com/dandi/dandi.github.io/assets/871137/6df49a29-dc45-4943-95db-1a5d744836a5)
