### PR TITLE
Remove `Home` button from top navigation bar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,6 @@
   	</div>
   	<div class="collapse navbar-collapse" id="navbar-collapse-1">
   	  <ul class="nav navbar-nav navbar-right">
-		<li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
 		<li><a href="https://dandiarchive.org">Data Portal</a></li>
   		<li><a href="https://www.dandiarchive.org/handbook/">Documentation</a></li>
   		<li><a href="http://hub.dandiarchive.org">DandiHub</a></li>


### PR DESCRIPTION
- Based on a [discussion](https://github.com/dandi/dandi.github.io/pull/67#issuecomment-1967833523) in #67, remove `Home` button as the `DANDI` logo links to the homepage.
- Proposed changes:
![image](https://github.com/dandi/dandi.github.io/assets/871137/be563e59-139a-4dfe-8d74-a92335b1aadf)
