### PR TITLE
Update dates on the `News` page to the `month-day-year` format

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,69 +1,69 @@
-- date: 2023 11 11 - 15
+- date: November 11-15, 2023
   headline: >-
     DANDI, NWB, and CatalystNeuro teams are hosting exhibit booth at
     <a href="https://www.sfn.org/meetings/neuroscience-2023/">SfN 2023</a>.
     See <a href="https://calendar.google.com/calendar/embed?src=3b6124a4c11e4842bf66da3d17a1a6054ee52d6c9ff1c51416575d438040b751%40group.calendar.google.com&ctz=America%2FNew_York">calendar</a> of events at the booth.
 
-- date: 2023 10 10 - 12
+- date: October 10-12, 2023
   headline: >-
     <a href="https://odin.mit.edu">
     Open Data In Neurophysiology (ODIN) Symposium @ MIT
     </a>
 
-- date: 2023 09 14
+- date: September 14, 2023
   headline: >-
     <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/Workshop_2023_Princeton/">NWB and DANDI Workshop at Princeton</a>
 
-- date: 2023 09 5-8
+- date: September 5-8, 2023
   headline: >-
     <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK16_2023_Granada_RH/">NeuroDataReHack 2 as a satellite for the IBRO World Congress (Granada, Spain)</a>
 
-- date: 2023 08 28
+- date: August 28, 2023
   headline: >-
     Scientists who have publicly shared neurophysiology data on DANDI present their data at
     <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK17_2023_OpenNeuroDataShowcase/">Open Neurodata Showcase 2023</a>
 
-- date: 2022 10 04
+- date: October 4, 2022
   headline: > 
     Paper outline the Neurodata Without Borders ecosystem including DANDI published in ELife 
     (<a href="https://elifesciences.org/articles/78362">Link</a>).
 
-- date: 2022 03 08
+- date: March 8, 2022
   headline: >
     <a href="https://www.dandiarchive.org/2022/03/08/microscopy-workshop.html">
     DANDI Human ex-vivo microscopy workshop/hackathon</a>.
 
-- date: 2022 02 15 - 02 18
+- date: February 15-18, 2022
   headline: >
     DANDI and NWB teams hold
     <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK12_2022_Remote/">
     2022 NWB-DANDI Remote Developer Hackathon</a>.
 
-- date: 2021 11 01
+- date: November 1, 2021
   headline: >
     Virtual hands-on <a href="https://www.dandiarchive.org/2021/10/13/dandi-workshop.html">DANDI User Workshop</a>.
 
-- date: 2021 03 30 - 04 01
+- date: March 30 - April 1, 2021
   headline: >
     DANDI and NWB teams hold
     <a href="https://neurodatawithoutborders.github.io/nwb_hackathons/HCK10_2021_Remote/">
     2021 NWB-DANDI Remote Developer Hackathon</a>.
 
-- date: 2020 02 03-06
+- date: February 3-6, 2020
   headline: >
     DANDI participated in
     <a href="https://alleninstitute.org/what-we-do/brain-science/events-training/2020-nwb-hackathon/">
     NWB hackathon at Allen Institute</a>.
 
-- date: 2019 10 19-23
+- date: October 19-23, 2019
   headline: >
     DANDI was at SFN and thanks INCF for hospitality.
 
-- date: 2019 10 18
+- date: October 18, 2019
   headline: >
     DANDI attended BICCN meeting prior to SFN.
 
-- date: 2019 07 22
+- date: July 22, 2019
   headline: >
     MIT, Dartmouth, and Kitware received BRAIN Initiative award for a cellular neurophysiology archive.
     <a href="https://projectreporter.nih.gov/project_info_description.cfm?aid=9795271">Award details</a>.


### PR DESCRIPTION
## Description
- Currently, on the `News` page, the format of the dates is `year-month-day`:
![image](https://github.com/dandi/dandi.github.io/assets/871137/c21436d9-0a61-4e51-94b0-66211de321a6)

- I prefer the `year-month-day` format for most cases but on the homepage its not too intuitive, especially when there are ranges.

## Changes
- The proposed changes updates the date format to `month-day-year`, and updates to naming the month:
![image](https://github.com/dandi/dandi.github.io/assets/871137/246b2849-6001-4467-ab0c-5436bf31666d)
