### PR TITLE
fixed blog figures

### DIFF
--- a/_posts/2024-09-09-data_reuse_000458.md
+++ b/_posts/2024-09-09-data_reuse_000458.md
@@ -27,7 +27,7 @@ This rebound excitation, in turn, drives the second component of the ERP – a c
 After their experiments, Claar and her team published their data on DANDI, ensuring that it would remain publicly accessible for any future researchers who wanted to use it. The dataset and manuscript were prepared and published concurrently, which ensured that the dataset included all the paper-relevant data and metadata and curious reviewers could inspect the data directly if they so wished.
 
 <figure>
-    <img src="data_reuse_000458_elife-fig7.jpg" alt="Figure 1" width="50%">
+    <img src="../_posts/data_reuse_000458_elife-fig7.jpg" alt="Figure 1" width="50%">
     <figcaption> <b> Figure 1: Brain state modulates the ERP via cortico-thalamo-cortical interactions. </b> <br>
     (A) Butterfly plot of ERPs during non-running (quiet wakefulness), running (active wakefulness), and isoflurane-anesthetized states. <br>
     (B) Normalized firing rate, reported as a z-score of the average, pre-stimulus firing rate, of all RS neurons recorded by the Neuropixels probes targeting the stimulated cortex (MO) and SM-TH. <br>
@@ -58,7 +58,7 @@ Conversely, setting it to the hyperpolarizing regime (-80mV) mimicked the respon
 This data provides evidence for the hypothesized bidirectional relationship.
 
 <figure>
-    <img src="data_reuse_000458_cell-fig4.jpg" alt="Figure 2" width="50%">
+    <img src="../_posts/data_reuse_000458_cell-fig4.jpg" alt="Figure 2" width="50%">
     <figcaption> <b> Figure 2: Shunting inhibition promotes local network desynchronization and response flexibility. </b> <br>
     (A) High-density Neuropixels (NPXs) recordings were used to compare spiking activity in the same cortical neurons under awake and anesthetized conditions. <br>
     (B) Example raster plots show the spiking activity of a population of neurons in somatosensory cortex (SS). Spiking activity is shown across three stimulation trials for each condition. <br>


### PR DESCRIPTION
This PR should fix the figures in the blog, based on this [thread](https://stackoverflow.com/questions/40197197/how-can-i-display-an-image-in-a-post-on-a-blog-powered-by-jekyll/40198284#40198284).

But, it worked locally before this fix, so I'm not sure if there is a good way to test this before merging.