### PR TITLE
fixed links for data reuse blog post

### DIFF
--- a/_posts/2024-09-09-data_reuse_000458.md
+++ b/_posts/2024-09-09-data_reuse_000458.md
@@ -39,7 +39,7 @@ Just a few months later, in November 2023, Drs. Richard Burman, Paul Brodersen a
 Their findings were published in the journal _Neuron_ with the article, [“Active cortical networks promote shunting fast synaptic inhibition _in vivo_”](https://doi.org/10.1016/j.neuron.2023.08.005).
 They also investigated the effects of anesthesia on brain activity, but narrowed their focus to the differential function of a specific receptor subtype: [GABA<sub>A</sub>R](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2648504/).
 
-Burman and Brodersen's team used a technique called [_in vivo_ gramicidin perforated patch-clamp recording](10.1254/fpj.113.339), combined with [optogenetic](10.1097/ICU.0000000000000140) activation of GABAergic synaptic inputs.
+Burman and Brodersen's team used a technique called [_in vivo_ gramicidin perforated patch-clamp recording](https://doi.org/10.1254/fpj.113.339), combined with [optogenetic](https://doi.org/10.1097/ICU.0000000000000140) activation of GABAergic synaptic inputs.
 They compared the GABA<sub>A</sub> receptor equilibrium potential (E<sub>GABA<sub>A</sub>R</sub>) in mice during wakefulness and under urethane anesthesia.
 
 Their findings were striking. In anesthetized mice, GABA<sub>A</sub> receptor responses were significantly hyperpolarizing, with an average equilibrium potential of -80.8mV.


### PR DESCRIPTION
A couple links were missing the `https://doi.org/` prefix to the doi.