### PR TITLE
Simplify section on former members

### DIFF
--- a/data/former_members.yml
+++ b/data/former_members.yml
@@ -1,26 +1,14 @@
 - name: Horea-Ioan Ioanas
-  info: Research Associate at PBS, Dartmouth College
-  email: chr@chymera.eu
-  number_educ: 4
-  education1: PhD in Neuroscience and Biomedical Engineering, ETH Zurich (CH)
-  education2: MSc in Molecular Biosciences and Neuroscience, Heidelberg University (DE)
-  education3: BSc in Molecular and Cellular Biology, Heidelberg University (DE)
-  education4: <a href="https://resources.chymera.eu/docs/cv-acad-m.pdf">CV</a>
+  info: Former Research Associate at Dartmouth College
 
 - name: Cody Baker
-  info: Head of NWB Conversions at <a href="http://www.catalystneuro.com">CatalystNeuro</a>
-  email: cody.baker@catalystneuro.com
-  number_educ: 1
-  education1: PhD in Applied and Computational Mathematics and Statistics from the University of Notre Dame
+  info: Former Head of NWB Conversions at CatalystNeuro
 
 - name: Daniel Chiquito
+  info: Former Senior R&D Engineer at Kitware
 
 - name: Michael Grauer
+  info: Former Technical Leader at Kitware
 
 - name: Bhavya Kandimalla
-  info: Intern, working on the DANDI project at MIT
-  email: bkandimalla.wpi@gmail.com
-  number_educ: 3
-  education1: BS Biology and Biotechnology, Worcester Polytechnic Institute
-  education2: MS Candidate Bioinformatics, Johns Hopkins University
-  education3: <a href="https://www.linkedin.com/in/bhavya-kandimalla-a02248100">Full CV</a>
+  info: Former Intern at MIT

--- a/layouts/team/list.html
+++ b/layouts/team/list.html
@@ -37,12 +37,6 @@
                         {{ if .email }}
                         <p><strong>Email:</strong> <a href="mailto:{{ .email }}">{{ .email }}</a></p>
                         {{ end }}
-                        <ul>
-                            {{ $teamMember := . }}
-                            {{ range seq 1 .number_educ }}
-                            <li>{{ index $teamMember (print "education" .) | safeHTML }}</li>
-                            {{ end }}
-                        </ul>
                     </div>
                 </div>
                 {{ end }}


### PR DESCRIPTION
Based on https://github.com/dandi/dandi-about/pull/104#issuecomment-2643861178.

Current:

![image](https://github.com/user-attachments/assets/0f179b5e-e7c5-4d2d-8022-4b7f0a54ece4)

Preview of changes:

![image](https://github.com/user-attachments/assets/64bd2456-97e9-4d59-817f-83a42df4f7ef)

Had to remove the list generation for the `education` keys in the `Former Members` section.  Otherwise the section looks as follows:

![image](https://github.com/user-attachments/assets/927f1b80-deb1-4add-bc99-64f32faa50c6)
