### PR TITLE
Add blog post: Neuromatch Impact Scholars Program

### DIFF
--- a/content/en/blog/2026-03-17-neuromatch-impact-scholars/index.md
+++ b/content/en/blog/2026-03-17-neuromatch-impact-scholars/index.md
@@ -1,0 +1,42 @@
+---
+title: "Get Your DANDI Data Analyzed by the Next Generation of Neuroscientists"
+author: Ben Dichter
+description: >
+    DANDI data submitters can propose projects based on their own datasets and get matched with a team of students through Neuromatch's Impact Scholars Program.
+tags: [ dandi, data-reuse, neuromatch, mentorship ]
+date: 2026-03-17
+---
+
+One of the most rewarding things about sharing data on DANDI is seeing other researchers use it to ask new questions. But with over 500 dandisets now available on the archive, a lot of that data is still waiting for someone to dig in. What if there were a structured way to connect your published data with motivated students who want to analyze it?
+
+That's exactly what [Neuromatch](https://neuromatch.io/)'s **Impact Scholars Program** offers. Through a partnership model, DANDI data submitters can propose projects based on their own datasets and get matched with a team of students to carry out the analysis, with the submitter serving as supervisor.
+
+## What is the Impact Scholars Program?
+
+Neuromatch runs intensive online courses in Computational Neuroscience, Deep Learning, and NeuroAI each July, reaching hundreds of students around the world. After the courses wrap up, the Impact Scholars Program gives selected teams of students the chance to continue working on a research project over six months (typically November through May). The program provides scholars with computing resources, professional development workshops, and structured mentorship.
+
+What makes this relevant to DANDI is that, in addition to projects that grow out of the summer courses, Neuromatch accepts project proposals from external partner organizations. This means you can propose a project centered on your own dandiset, and a team of 2 to 4 students will apply to work on it with you as their supervisor.
+
+## What do supervisors do?
+
+The time commitment is about 10 hours per month. In practice, this means meeting with your team twice a month to provide guidance, help troubleshoot analysis challenges, and keep the project on track. You'd also help with task planning and provide feedback on their work as it develops. Neuromatch provides a training session for supervisors and support from program staff throughout.
+
+In return, you get credited as a co-author on the team's micropublication, a citable write-up published on Zenodo with a DOI. If the collaboration goes well and both sides are interested, Neuromatch will support further work toward a full journal publication by extending the scholars' access to computing resources.
+
+Supervisors should hold a PhD in a relevant field (or have equivalent professional experience) and ideally be comfortable working in Python, since that's the primary language the scholars use.
+
+## Why this is a great fit for DANDI submitters
+
+If you've published a dandiset, you already have the two things this program needs: a well-organized, openly available dataset and the domain expertise to guide its analysis. NWB's standardized format means students can get started quickly using tools like [PyNWB](https://pynwb.readthedocs.io), [Pynapple](https://pynapple.org), [Neurosift](https://neurosift.app), and the [DANDI JupyterHub](https://hub.dandiarchive.org/), without weeks of reformatting or data wrangling. And the rich metadata in NWB files gives students a clear picture of what's in the data before they write a single line of code.
+
+For you as a data submitter, this is a way to get real scientific value out of your published data beyond its original study. Maybe there's a secondary analysis you've been meaning to do but haven't had the bandwidth for, or a question a student could explore with fresh eyes. The Impact Scholars Program provides the structure and student talent to make that happen.
+
+It also contributes to something we care about deeply in the DANDI and NWB communities: demonstrating that open data actually gets reused. Every project that analyzes a dandiset is a concrete example of the value of data sharing, and it strengthens the case for open science in neurophysiology.
+
+## How to get involved
+
+If you're interested in proposing a project for the next cycle of the Impact Scholars Program (the current cohort runs through May 2026, and the next one will follow the July 2026 Neuromatch Academy), reach out to the Neuromatch team at [impactscholars@neuromatch.io](mailto:impactscholars@neuromatch.io). You can also learn more about the supervisor role, including detailed expectations and FAQs, on the [Impact Scholars Supervisors page](https://neuromatch.io/mentors/).
+
+If you're a student or early-career researcher interested in analyzing open neurophysiology data, keep an eye on the [Neuromatch courses](https://neuromatch.io/courses/) this July. Completing a course is the first step toward eligibility for the Impact Scholars Program.
+
+We're looking forward to seeing DANDI data put to work through this program. If you have questions, feel free to reach out to us at [info@dandiarchive.org](mailto:info@dandiarchive.org) or to the Neuromatch team directly.

--- a/content/en/blog/2026-03-17-neuromatch-impact-scholars/index.md
+++ b/content/en/blog/2026-03-17-neuromatch-impact-scholars/index.md
@@ -9,7 +9,7 @@ date: 2026-03-17
 
 One of the most rewarding things about sharing data on DANDI is seeing other researchers use it to ask new questions. But with over 500 dandisets now available on the archive, a lot of that data is still waiting for someone to dig in. What if there were a structured way to connect your published data with motivated students who want to analyze it?
 
-That's exactly what [Neuromatch](https://neuromatch.io/)'s **Impact Scholars Program** offers. Through a partnership model, DANDI data submitters can propose projects based on their own datasets and get matched with a team of students to carry out the analysis, with the submitter serving as supervisor.
+That's exactly what [Neuromatch](https://neuromatch.io/)'s [**Impact Scholars Program**](https://neuromatch.io/impact-scholars-program/) offers. Through a partnership model, DANDI data submitters can propose projects based on their own datasets and get matched with a team of students to carry out the analysis, with the submitter serving as supervisor.
 
 ## What is the Impact Scholars Program?
 


### PR DESCRIPTION
## Summary
- Adds a new blog post describing how DANDI data submitters can propose projects and mentor students through Neuromatch's Impact Scholars Program
- Covers the program structure, supervisor role, and how to get involved

## Test plan
- [ ] Preview the blog post locally with Hugo to verify rendering
- [ ] Check all links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)